### PR TITLE
fix: use kind="tcp" for port enumeration (audit P1-3)

### DIFF
--- a/docs/audit-2026-04.md
+++ b/docs/audit-2026-04.md
@@ -1,0 +1,327 @@
+# portctl — Auditoría de diseño y seguridad (2026-04)
+
+> **Snapshot de auditoría — no es una lista de TODOs viva.** Los items que se están trabajando se trackean como issues en GitHub (milestone `v0.2.0` para los P0). Este documento queda como referencia técnica detallada para cada finding.
+
+Análisis del proyecto en estado del commit `57fbbf6`. Cubre `portctl.py`, `install.sh`, tests, CI y packaging.
+
+Prioridades:
+- 🔴 **P0** — Seguridad crítica. Tratar antes del próximo release.
+- 🟠 **P1** — Diseño / correctitud. Resolver antes de promocionar a 1.0.
+- 🟡 **P2** — Mejoras menores y deuda.
+
+---
+
+## 🔴 P0 — Seguridad crítica
+
+### P0-1. `install.sh` muta el fuente del repo durante la instalación
+
+**Archivo:** `install.sh:100`
+
+```bash
+sed -i '' "1s|.*|#!${PYTHON_PATH}|" "$SOURCE"
+```
+
+El installer reescribe la primera línea de `portctl.py` con un shebang absoluto al Python detectado. El commit `40d16a1` (*"fix: use env python3 shebang for portability"*) cambió explícitamente a `#!/usr/bin/env python3` para que el script fuera portable — el installer revierte ese cambio en cada ejecución.
+
+**Consecuencias:**
+- El working tree queda dirty después de instalar (`git status` muestra modificación).
+- El binario apunta a un Python específico. Si se desinstala (Homebrew upgrade, pyenv switch, cambio de venv), `portctl` rompe sin causa aparente.
+- No es portable entre máquinas: cada usuario obtiene un shebang distinto en su copia del archivo.
+
+**Fix propuesto:** no tocar el shebang. En su lugar, generar un wrapper en `/usr/local/bin/portctl`:
+```bash
+#!/usr/bin/env bash
+exec "$PYTHON_PATH" "$REPO/portctl.py" "$@"
+```
+o instalar vía `pipx install .` que aísla el entorno.
+
+---
+
+### P0-2. Symlink desde `/usr/local/bin` a un path mutable por el usuario
+
+**Archivo:** `install.sh:106`
+
+```bash
+sudo ln -sf "$SOURCE" "$TARGET"
+```
+
+`/usr/local/bin/portctl` apunta a un archivo dentro del repo del usuario (`$HOME/Projects/...`). El target es **escribible por el UID del usuario**, lo que significa que cualquier proceso que tenga ese UID (incluyendo malware que se ejecuta como el user) puede modificar el script.
+
+**Vector de escalada:**
+1. Atacante con acceso al UID del user modifica `portctl.py` agregando comandos arbitrarios.
+2. Usuario ejecuta `sudo portctl kill <port>` (típico cuando matás un proceso de root).
+3. El código del atacante corre con privilegios de root.
+
+**Fix propuesto:** copiar el archivo a un destino root-owned, o (mejor) usar `pipx` que crea venv aislado en `~/.local/pipx/venvs/...` con permisos sanos.
+
+---
+
+### P0-3. `pip install` sin pinning ni verificación de hashes
+
+**Archivos:** `install.sh:79,83,88`, `requirements.txt`
+
+```bash
+pip install --upgrade rich typer psutil
+```
+
+`requirements.txt` usa sólo `>=` sin lock file, sin `--require-hashes`, sin pinning exacto. Para una herramienta que se ejecuta con permisos para enviar `SIGKILL` a procesos del sistema, una versión comprometida de cualquiera de las tres dependencias compromete la máquina.
+
+Adicional: `install.sh:83` usa `--break-system-packages` para bypassear PEP 668 sin avisar al usuario, lo que puede ensuciar el Python del sistema.
+
+**Fix propuesto:**
+- `requirements.txt` con versiones exactas (`==`) y hashes generados por `pip-compile --generate-hashes`.
+- Migrar a `pipx install .` para aislar dependencias.
+
+---
+
+### P0-4. Modificación de `~/.zshrc` no idempotente y sin uninstall
+
+**Archivo:** `install.sh:117-123`
+
+```bash
+{
+  echo ""
+  echo "# portctl"
+  echo "export PATH=\"$INSTALL_DIR:\$PATH\""
+} >> "$ZSHRC"
+```
+
+La verificación previa (línea 115) chequea si `$INSTALL_DIR` ya está en `$PATH`, pero si el usuario lo borró del PATH por cualquier razón y reinstala, vuelve a agregarlo. No hay backup de `.zshrc`. No existe script de uninstall.
+
+**Fix propuesto:** chequear contra el contenido textual de `.zshrc` (no contra `$PATH`), hacer backup `.zshrc.bak.portctl-<timestamp>`, proveer `uninstall.sh`.
+
+---
+
+## 🟠 P1 — Diseño y correctitud
+
+### P1-1. Race condition: PID reuse entre listar y matar
+
+**Archivos:** `portctl.py:121-132` (`kill_port`), `portctl.py:201-221` (`cmd_kill`), `portctl.py:238-296` (`cmd_interactive`)
+
+Flujo:
+1. `get_open_ports()` produce una snapshot con `pid`.
+2. Se le muestra al usuario y se espera confirmación (en `interactive` el delay puede ser de minutos).
+3. `kill_port(port)` re-itera procesos buscando el puerto y ejecuta `os.kill(pid, ...)`.
+
+Entre los pasos 1 y 3, el proceso original puede haber terminado y el kernel puede reusar su PID para otro proceso del sistema. Resultado: matás el proceso equivocado.
+
+**Fix propuesto:** capturar `psutil.Process(pid).create_time()` al listar, comparar antes de `os.kill` para confirmar que es el mismo proceso. Mejor aún: usar `proc.terminate()`/`proc.kill()` directamente (psutil valida internamente).
+
+---
+
+### P1-2. Performance: O(N_procesos) syscalls en lugar de uno solo
+
+**Archivos:** `portctl.py:49-51`, `portctl.py:123-125`
+
+```python
+for proc in psutil.process_iter(["pid", "name", "username"]):
+    conns = proc.net_connections(kind="inet")
+```
+
+En macOS cada `proc.net_connections()` ejecuta un syscall costoso (libproc) por proceso. En sistemas con cientos de procesos, cada listado tarda 100-200ms.
+
+**⚠️ Corrección post-auditoría (verificado 2026-04-29)**: el fix originalmente propuesto **no funciona en macOS sin sudo**. `psutil.net_connections(kind="tcp")` parece global pero internamente itera procesos (ver `_psosx.py:226-241` de psutil) y solo captura `NoSuchProcess`, no `AccessDenied`. La primera vez que toca un proceso ajeno al user, levanta excepción y se cae todo el call. Probado empíricamente en este repo.
+
+```python
+# NO funciona en macOS sin sudo:
+for conn in psutil.net_connections(kind="tcp"):
+    ...
+```
+
+**Caminos viables (a investigar)**:
+- Usar `lsof -nP -iTCP` vía `subprocess` — más rápido en macOS y no requiere root para los puertos del user. Rompe la abstracción "puro psutil".
+- Detectar si corremos como root y elegir el path global, si no fallback al per-process. Más código, mismo techo de performance para el caso común.
+- Aceptar que la performance actual (44ms con ~64 ports en una máquina típica) es suficiente y cerrar este finding como wontfix.
+
+**Lo que sí se puede hacer**: cambiar `kind="inet"` → `kind="tcp"`. Cierra P1-3 (correctitud) sin tocar performance. Aplicado en PR del 2026-04-29.
+
+---
+
+### P1-3. `kind="inet"` mezcla TCP y UDP, columna "Proto" miente
+
+**Archivo:** `portctl.py:51,71`
+
+`psutil` con `kind="inet"` devuelve TCP+UDP. Las conexiones UDP quedan filtradas **por accidente** porque su `status` es `NONE` y no está en `VALID_STATES`. Si `VALID_STATES` cambia en el futuro, entrarán entradas UDP rotuladas como `"proto": "TCP"` (hardcoded).
+
+**Fix propuesto:** usar `kind="tcp"`. Si más adelante se quiere soportar UDP, agregarlo explícitamente.
+
+---
+
+### P1-4. `kill_port` no captura `PermissionError`
+
+**Archivo:** `portctl.py:130`
+
+```python
+except (psutil.NoSuchProcess, psutil.AccessDenied, ProcessLookupError):
+```
+
+`os.kill()` lanza `PermissionError` (errno EPERM) cuando el proceso pertenece a otro UID (root, otro user). El `psutil.AccessDenied` capturado es de `psutil`, no de `os.kill`. Resultado: traceback feo si intentás matar un proceso de root sin sudo.
+
+**Fix propuesto:** agregar `PermissionError` al `except`, o usar `proc.terminate()` que lo encapsula.
+
+---
+
+### P1-5. `kill_port` retorna `True` con semántica engañosa
+
+**Archivo:** `portctl.py:121-132`
+
+Si dos procesos comparten el puerto (uno root, uno user) y `os.kill` mata sólo al del user, devuelve `True` y la UI muestra `"✓ Closed"` — pero el puerto sigue ocupado.
+
+**Fix propuesto:** devolver una estructura `(killed: list[int], failed: list[int])` y dejar que la UI decida el mensaje. Confirmar con `proc.wait(timeout=...)` que el proceso efectivamente terminó.
+
+---
+
+### P1-6. `cmd_interactive` hardcodea `LISTEN` pero el help promete genérico
+
+**Archivo:** `portctl.py:240`
+
+```python
+listen_ports = get_open_ports(filter_state="LISTEN")
+```
+
+El help dice "browse and manage ports" sin restringir estado. La UI ignora `ESTABLISHED` y `CLOSE_WAIT`.
+
+**Fix propuesto:** parámetro opcional `--state` en `interactive`, o tabs/filtros dentro del modo interactivo.
+
+---
+
+### P1-7. Sin separación de capas — tests sólo mockean
+
+**Archivos:** `portctl.py` (todo), `tests/test_portctl.py`, `tests/test_cli.py`
+
+Para 300 líneas pasa, pero ya hay tres responsabilidades mezcladas:
+- **Dominio:** `get_open_ports`, `kill_port`.
+- **Presentación:** `build_table`, `status_color`.
+- **Controllers:** `cmd_list`, `cmd_kill`, `cmd_interactive`.
+
+Consecuencia: **todos los tests mockean `psutil.process_iter`**. Ningún test detectaría que la API de psutil cambia (rename de `net_connections`, cambio de tipo de retorno, etc.).
+
+**Fix propuesto:** Hexagonal liviano:
+```
+portctl/
+├── core.py     # get_open_ports, kill_port — sin rich/typer
+├── view.py     # build_table, status_color — sólo rich
+└── cli.py      # comandos typer — orquesta core + view
+```
+Agregar test de integración real que abra un socket efímero, lo liste y lo cierre.
+
+---
+
+### P1-8. Tres formas de instalar conviven mal
+
+**Archivos:** `pyproject.toml:44-48`, `install.sh`, `README.md:48-58`
+
+- `[project.scripts] portctl = "portctl:app"` (entrypoint pip).
+- `install.sh` que symlinkea `portctl.py` directo.
+- `README` muestra `sudo ln -sf ...` manual.
+
+Las tres rutas coexisten sin coordinación. Una debería ser la oficial; las otras documentadas como alternativas avanzadas.
+
+**Fix propuesto:** elegir `pipx install .` como camino oficial, deprecar `install.sh` o reescribirlo como wrapper de `pipx`.
+
+---
+
+### P1-9. `release.yml` no firma artifacts
+
+**Archivo:** `.github/workflows/release.yml`
+
+Para una herramienta que pide privilegios para matar procesos del sistema, las release deberían firmarse con `actions/attest-build-provenance` o sigstore. Hoy cualquier comprometimiento del repo permite distribuir un artifact malicioso.
+
+**Fix propuesto:** agregar step `actions/attest-build-provenance@v1` después del build.
+
+---
+
+## 🟡 P2 — Mejoras menores
+
+### P2-1. `set -euo pipefail` + pipe a `grep` puede romper silenciosamente
+
+**Archivo:** `install.sh:55`
+
+```bash
+version=$("$candidate" --version 2>&1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
+```
+
+Con `pipefail`, si `grep` no matchea, falla todo el script. Funciona porque Python siempre devuelve versión, pero es frágil.
+
+**Fix:** `|| true` al final del pipe, o restructurar.
+
+---
+
+### P2-2. `chmod +x` puede fallar en repos read-only
+
+**Archivo:** `install.sh:101`
+
+Si el repo está en `/opt/portctl` o pertenece a otro UID, `chmod` falla.
+
+**Fix:** chmod sólo si el archivo es escribible, o quitar (no se necesita si usamos wrapper).
+
+---
+
+### P2-3. `kill_port` pide `name` que nunca lee
+
+**Archivo:** `portctl.py:123`
+
+```python
+for proc in psutil.process_iter(["pid", "name"]):
+```
+
+`name` no se usa en la función. Carga innecesaria.
+
+---
+
+### P2-4. README muestra una tabla de ejemplo que no coincide con `build_table`
+
+**Archivo:** `README.md:69-76`
+
+Las columnas del ejemplo (Protocol con `0.0.0.0:3000`) no coinciden con las de `build_table` (Proto / Address separadas). Confunde al lector.
+
+---
+
+### P2-5. Validación de `--state` con string libre + check manual
+
+**Archivo:** `portctl.py:152-165`
+
+Typer permite cualquier string en `--state` y validás manualmente. Con `enum.Enum` typer valida automáticamente y muestra valores válidos en `--help`.
+
+**Fix:**
+```python
+class State(str, Enum):
+    listen = "listen"
+    established = "established"
+    close_wait = "close_wait"
+```
+
+---
+
+### P2-6. CI sólo en `macos-latest`
+
+**Archivo:** `.github/workflows/ci.yml`
+
+Si en algún momento se quiere abrir a otros sistemas (Linux para WSL, FreeBSD), agregar matriz de OS.
+
+---
+
+### P2-7. Sin logging de acciones destructivas
+
+`kill_port` no deja rastro de quién mató qué proceso. Para una herramienta que envía `SIGKILL`, sería razonable loggear a `~/.local/state/portctl/log` con timestamp, port, pid, user.
+
+---
+
+## Resumen ejecutivo
+
+| Prioridad | ID | Problema | Acción |
+|-----------|----|----------|--------|
+| 🔴 P0 | P0-1 | `install.sh` muta el fuente | Quitar `sed`, usar wrapper o pipx |
+| 🔴 P0 | P0-2 | Symlink en `/usr/local/bin` a path mutable | Copiar archivo o usar pipx |
+| 🔴 P0 | P0-3 | `pip install` sin pinning | Pin exacto + hashes, idealmente pipx |
+| 🔴 P0 | P0-4 | `~/.zshrc` no idempotente | Idempotencia + uninstall script |
+| 🟠 P1 | P1-1 | Race condition PID reuse | Sentinel con `create_time()` |
+| 🟠 P1 | P1-2 | N+1 syscalls en port scan | `psutil.net_connections(kind="tcp")` global |
+| 🟠 P1 | P1-3 | `kind="inet"` mezcla TCP/UDP | Cambiar a `kind="tcp"` |
+| 🟠 P1 | P1-4 | `PermissionError` no capturado | Agregar al except |
+| 🟠 P1 | P1-5 | `kill_port` retorna True engañoso | Devolver estructura detallada |
+| 🟠 P1 | P1-6 | `interactive` sólo LISTEN | Soportar otros estados |
+| 🟠 P1 | P1-7 | Sin separación de capas | Modularizar `core/view/cli` |
+| 🟠 P1 | P1-8 | Tres rutas de instalación | Elegir `pipx` como oficial |
+| 🟠 P1 | P1-9 | Release sin firmar | Sigstore / attest-build-provenance |
+| 🟡 P2 | P2-1..7 | Detalles menores | Cuando se toque la zona afectada |

--- a/portctl.py
+++ b/portctl.py
@@ -48,7 +48,7 @@ def get_open_ports(filter_port: Optional[int] = None, filter_state: Optional[str
 
     for proc in psutil.process_iter(["pid", "name", "username"]):
         try:
-            conns = proc.net_connections(kind="inet")
+            conns = proc.net_connections(kind="tcp")
             for conn in conns:
                 if not conn.laddr or conn.status not in VALID_STATES:
                     continue
@@ -122,7 +122,7 @@ def kill_port(port: int, force: bool = False) -> bool:
     killed = []
     for proc in psutil.process_iter(["pid", "name"]):
         try:
-            for conn in proc.net_connections(kind="inet"):
+            for conn in proc.net_connections(kind="tcp"):
                 if conn.laddr and conn.laddr.port == port:
                     os.kill(proc.pid, signal.SIGKILL if force else signal.SIGTERM)
                     killed.append(proc.pid)

--- a/tests/test_portctl.py
+++ b/tests/test_portctl.py
@@ -36,6 +36,7 @@ class TestGetOpenPorts:
         # Test
         ports = get_open_ports()
 
+        mock_proc.net_connections.assert_called_once_with(kind="tcp")
         assert len(ports) == 1
         assert ports[0]["port"] == 8080
         assert ports[0]["pid"] == 1234


### PR DESCRIPTION
## Summary

- Changes `psutil` calls in `get_open_ports` and `kill_port` from `kind="inet"` to `kind="tcp"`. Closes audit finding **P1-3** (correctness — `inet` returns TCP+UDP, UDP was filtered by accident).
- Moves `issues.md` → `docs/audit-2026-04.md` as a snapshot reference. The live tracker is now GitHub issues under milestone [v0.2.0](https://github.com/0xBroom/portctl/milestone/1).
- Documents an investigated-but-deferred finding for **P1-2**: `psutil.net_connections()` global call is broken on macOS without sudo (only catches `NoSuchProcess`, not `AccessDenied`). Verified empirically on this machine.

## Why this PR is small

The original audit recommendation for P1-2 was a global single-syscall refactor. Smoke-tested against the real system: it crashes on the first foreign process. Reverted that path and shipped only the part that actually works (P1-3). P1-2 stays open with a verified note in `docs/audit-2026-04.md` so the next attempt knows what doesn't work.

## Test plan

- [x] `pytest tests/ -v` — 25 passed
- [x] `ruff check` and `ruff format --check` — clean
- [x] Smoke test: `python3 -c "from portctl import get_open_ports; ..."` against real psutil (44ms / 64 ports)
- [ ] Manual: run `portctl list`, `portctl list -s listen`, `portctl kill <port>` after merge to confirm UX unchanged