### PR TITLE
chore: add ubuntu-latest to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,12 @@ jobs:
         run: python -m ruff format --check portctl.py tests
 
   test:
-    name: Test (Python ${{ matrix.python-version }})
-    runs-on: macos-latest
+    name: Test (${{ matrix.os }} · Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [macos-latest, ubuntu-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:


### PR DESCRIPTION
## Summary

Expands the \`test\` job in \`.github/workflows/ci.yml\` to run on both \`macos-latest\` and \`ubuntu-latest\` across the existing Python version matrix. Eight matrix cells total — four per OS.

## Why

PR #6 declares Linux as a first-class supported platform alongside macOS (new \`Operating System :: POSIX :: Linux\` classifier in \`pyproject.toml\`, README and CONTRIBUTING updated, install path moved to \`pipx install .\`). Without expanding the test matrix, that support claim is verified only manually — any future change that breaks Linux behavior would slip through CI.

## What changed

\`\`\`diff
   test:
-    name: Test (Python \${{ matrix.python-version }})
-    runs-on: macos-latest
+    name: Test (\${{ matrix.os }} · Python \${{ matrix.python-version }})
+    runs-on: \${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [macos-latest, ubuntu-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
\`\`\`

Net diff: +3, -2. \`fail-fast: false\` is preserved so a single cell failure surfaces the others.

## Scope decisions

- **\`lint\` job intentionally left on \`macos-latest\`.** Ruff is OS-agnostic; running it on both OSes adds no signal, only minutes. If the team later wants to migrate it to \`ubuntu-latest\` for the cost saving, that's a separate decision.
- **\`release.yml\` not touched.** It already builds on \`ubuntu-latest\`. Artifact signing (P1-9 from the audit) is a different concern.
- **No dependency-flow changes.** The current \`pip install -r requirements.txt\` on the sandboxed CI runner is OS-portable as-is.

## Test plan

- [x] All 8 test matrix cells pass green (4 macOS × Python versions, 4 Ubuntu × Python versions).
- [x] \`lint\` job continues to pass on \`macos-latest\` (untouched).
- [x] No regressions on existing macOS matrix cells.

## Closes

Closes #7