### PR TITLE
fix: handle RuntimeError from psutil C extension on macOS (closes #9)

### DIFF
--- a/portctl.py
+++ b/portctl.py
@@ -72,7 +72,9 @@ def get_open_ports(filter_port: Optional[int] = None, filter_state: Optional[str
                         "addr": str(conn.laddr.ip),
                     }
                 )
-        except (psutil.NoSuchProcess, psutil.AccessDenied):
+        except (psutil.NoSuchProcess, psutil.AccessDenied, RuntimeError):
+            # RuntimeError: psutil's macOS C extension can leak raw errors from
+            # proc_pidinfo(PROC_PIDLISTFDS) that wrap_exceptions doesn't map.
             continue
 
     ports.sort(key=lambda x: x["port"])
@@ -127,7 +129,7 @@ def kill_port(port: int, force: bool = False) -> bool:
                     os.kill(proc.pid, signal.SIGKILL if force else signal.SIGTERM)
                     killed.append(proc.pid)
                     break
-        except (psutil.NoSuchProcess, psutil.AccessDenied, ProcessLookupError):
+        except (psutil.NoSuchProcess, psutil.AccessDenied, ProcessLookupError, RuntimeError):
             continue
     return len(killed) > 0
 

--- a/tests/test_portctl.py
+++ b/tests/test_portctl.py
@@ -116,6 +116,39 @@ class TestGetOpenPorts:
         assert len(ports) == 0
 
     @patch("portctl.psutil.process_iter")
+    def test_get_open_ports_handles_runtime_error(self, mock_process_iter):
+        """Regression: psutil's macOS C extension can leak RuntimeError from
+        proc_pidinfo(PROC_PIDLISTFDS); the iteration must not die. (Issue #9)"""
+        mock_proc = Mock()
+        mock_proc.net_connections.side_effect = RuntimeError("proc_pidinfo(PROC_PIDLISTFDS) 2/2 syscall failed")
+        mock_process_iter.return_value = [mock_proc]
+
+        ports = get_open_ports()
+        assert len(ports) == 0
+
+    @patch("portctl.psutil.process_iter")
+    def test_get_open_ports_continues_after_runtime_error(self, mock_process_iter):
+        """Regression: a bad PID raising RuntimeError must not prevent the
+        rest of the iteration from being scanned. (Issue #9)"""
+        bad_proc = Mock()
+        bad_proc.net_connections.side_effect = RuntimeError("proc_pidinfo(PROC_PIDLISTFDS) 2/2 syscall failed")
+
+        good_proc = Mock()
+        good_proc.pid = 4321
+        good_proc.info = {"name": "ok-app", "username": "testuser"}
+        good_conn = Mock()
+        good_conn.laddr = Mock(port=8080, ip="127.0.0.1")
+        good_conn.status = "LISTEN"
+        good_proc.net_connections.return_value = [good_conn]
+
+        mock_process_iter.return_value = [bad_proc, good_proc]
+
+        ports = get_open_ports()
+        assert len(ports) == 1
+        assert ports[0]["port"] == 8080
+        assert ports[0]["pid"] == 4321
+
+    @patch("portctl.psutil.process_iter")
     def test_get_open_ports_sorts_by_port(self, mock_process_iter):
         """Test that results are sorted by port number"""
         mock_proc = Mock()
@@ -206,6 +239,28 @@ class TestKillPort:
 
         assert result is True
         mock_os_kill.assert_called_with(1234, signal.SIGKILL)
+
+    @patch("portctl.os.kill")
+    @patch("portctl.psutil.process_iter")
+    def test_kill_port_skips_runtime_error_and_kills_target(self, mock_process_iter, mock_os_kill):
+        """Regression: a bad PID raising RuntimeError must not prevent the
+        target on a later PID from being killed. (Issue #9)"""
+        bad_proc = Mock()
+        bad_proc.net_connections.side_effect = RuntimeError("proc_pidinfo(PROC_PIDLISTFDS) 2/2 syscall failed")
+
+        target_proc = Mock()
+        target_proc.pid = 4321
+        target_conn = Mock()
+        target_conn.laddr = Mock(port=8080)
+        target_proc.net_connections.return_value = [target_conn]
+
+        mock_process_iter.return_value = [bad_proc, target_proc]
+
+        result = kill_port(8080)
+
+        assert result is True
+        mock_os_kill.assert_called_once()
+        assert mock_os_kill.call_args[0][0] == 4321
 
 
 class TestValidStates:


### PR DESCRIPTION
## Summary

- Adds `RuntimeError` to the exception tuple in `get_open_ports` and `kill_port`. psutil's macOS C extension leaks a raw `RuntimeError` from `cext.proc_net_connections` when `proc_pidinfo(PROC_PIDLISTFDS)` fails for reasons not mapped to `EACCES`/`ESRCH` — the wrapper at `psutil/_psosx.py:344` only translates `ProcessLookupError`/`PermissionError`. One bad PID in the iteration would kill the entire scan with `RuntimeError: proc_pidinfo(PROC_PIDLISTFDS) 2/2 syscall failed`.
- Adds three regression tests that mock `proc.net_connections` to raise `RuntimeError` and assert the iteration continues, including a multi-process scenario where one bad PID precedes a good one.

Closes #9.

## Why catch a broad exception here

Catching `RuntimeError` is normally a smell, but here the source is a known psutil C-extension leak on macOS, and the iteration's intent is exactly "skip processes we can't introspect, keep going" — same as the existing `NoSuchProcess`/`AccessDenied` catch. This is a follow-up to audit P1-2 and expands P1-4.

## Test plan

- [x] `ruff check` and `ruff format --check` — clean on `portctl.py` and `tests/`.
- [x] `pytest tests/` — **28 passed** (was 25, +3 new regression tests).
- [x] Smoke test on macOS 26.3.1: `get_open_ports(filter_state='listen')` returned 16 listening ports without crashing.
- [ ] Reviewer to confirm `portctl list` runs end-to-end on the originally affected macOS box.