### PR TITLE
feat!: rename project to lsport (v0.3.0)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Report a problem to help us improve portctl
+about: Report a problem to help us improve lsport
 title: "[Bug]: "
 labels: ["bug"]
 assignees: []
@@ -34,7 +34,7 @@ Paste full command output here
 
 - OS: macOS version (e.g., 14.5)
 - Python version: output of `python3 --version`
-- portctl version: output of `portctl --help` or commit/tag if running from source
+- lsport version: output of `lsport --help` or commit/tag if running from source
 - Installation method: install script / source / pip
 
 ## Additional Context

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea for portctl
+about: Suggest an idea for lsport
 title: "[Feature]: "
 labels: ["enhancement"]
 assignees: []
@@ -26,7 +26,7 @@ Describe any alternative solutions or workarounds you've considered.
 
 ```bash
 # Example command usage
-portctl ...
+lsport ...
 ```
 
 ## Additional Context

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@ Describe how reviewers can validate this change.
 ```bash
 # Example
 python3 -m pytest tests/ -v
-python3 -m ruff check portctl.py
+python3 -m ruff check lsport.py
 ```
 
 ## Screenshots / Terminal Output (if relevant)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run ruff check
-        run: python -m ruff check portctl.py tests
+        run: python -m ruff check lsport.py tests
 
       - name: Run ruff format check
-        run: python -m ruff format --check portctl.py tests
+        run: python -m ruff format --check lsport.py tests
 
   test:
     name: Test (${{ matrix.os }} · Python ${{ matrix.python-version }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,21 +56,23 @@ jobs:
           generate_release_notes: true
           files: dist/*
 
-  # pypi-publish:
-  #   name: Publish to PyPI
-  #   runs-on: ubuntu-latest
-  #   needs: build
-  #   if: startsWith(github.ref, 'refs/tags/v')
-  #   environment:
-  #     name: pypi
-  #     url: https://pypi.org/p/portctl
-  #
-  #   steps:
-  #     - name: Download build artifacts
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: dist
-  #         path: dist
-  #
-  #     - name: Publish package distributions to PyPI
-  #       uses: pypa/gh-action-pypi-publish@release/v1
+  pypi-publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/lsport
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-05-09
+
+### BREAKING
+
+- **Project renamed from `portctl` to `lsport`.** The `portctl` command no
+  longer exists. The new command is `lsport`. Existing installations must be
+  removed and reinstalled under the new name:
+
+  ```bash
+  pipx uninstall portctl
+  pipx install lsport
+  ```
+
+  No `portctl` shim is provided. The Python module is now `lsport` (replacing
+  `portctl`); any code importing `from portctl import ...` must be updated to
+  `from lsport import ...`.
+
+- Repository moved to <https://github.com/0xBroom/lsport>. GitHub redirects
+  preserve old clone URLs, but updating remotes to the new URL is recommended:
+
+  ```bash
+  git remote set-url origin git@github.com:0xBroom/lsport.git
+  ```
+
+### Added
+
+- First release published to PyPI as
+  [`lsport`](https://pypi.org/project/lsport/), via OIDC Trusted Publishing
+  from GitHub Actions.
+
 ## [0.2.0] - 2026-05-09
 
 ### Added
@@ -68,5 +98,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved type annotations and formatting consistency.
 - Added linting and formatting configuration via Ruff.
 
-[0.2.0]: https://github.com/0xBroom/portctl/releases/tag/v0.2.0
-[0.1.0]: https://github.com/0xBroom/portctl/releases/tag/v0.1.0
+[0.3.0]: https://github.com/0xBroom/lsport/releases/tag/v0.3.0
+[0.2.0]: https://github.com/0xBroom/lsport/releases/tag/v0.2.0
+[0.1.0]: https://github.com/0xBroom/lsport/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to portctl
+# Contributing to lsport
 
-First off, thank you for considering contributing to portctl! It's people like you that make portctl such a great tool.
+First off, thank you for considering contributing to lsport! It's people like you that make lsport such a great tool.
 
 ## Code of Conduct
 
@@ -50,8 +50,8 @@ Enhancement suggestions are tracked as GitHub issues. When creating an enhanceme
 1. **Clone your fork:**
 
    ```bash
-   git clone https://github.com/YOUR_USERNAME/portctl.git
-   cd portctl
+   git clone https://github.com/YOUR_USERNAME/lsport.git
+   cd lsport
    ```
 
 2. **Install in editable mode via pipx:**
@@ -60,14 +60,14 @@ Enhancement suggestions are tracked as GitHub issues. When creating an enhanceme
    pipx install --editable .
    ```
 
-   This creates an isolated venv for `portctl`, exposes the `portctl`
-   command on your `PATH`, and tracks edits to `portctl.py` live — no
+   This creates an isolated venv for `lsport`, exposes the `lsport`
+   command on your `PATH`, and tracks edits to `lsport.py` live — no
    reinstall needed after each change.
 
 3. **Install dev dependencies into the pipx venv:**
 
    ```bash
-   pipx inject portctl pytest pytest-cov ruff mypy
+   pipx inject lsport pytest pytest-cov ruff mypy
    ```
 
    Or, if you prefer working in a regular virtualenv for development:
@@ -88,13 +88,13 @@ We use pytest for testing. Make sure all tests pass before submitting a PR:
 pytest
 
 # Run with coverage
-pytest --cov=portctl
+pytest --cov=lsport
 
 # Run specific test file
-pytest tests/test_portctl.py
+pytest tests/test_lsport.py
 
 # Run a specific test
-pytest tests/test_portctl.py::TestGetOpenPorts::test_get_open_ports_basic
+pytest tests/test_lsport.py::TestGetOpenPorts::test_get_open_ports_basic
 ```
 
 ### Code Style
@@ -103,13 +103,13 @@ We use [ruff](https://github.com/astral-sh/ruff) for linting and formatting:
 
 ```bash
 # Check for linting issues
-python3 -m ruff check portctl.py
+python3 -m ruff check lsport.py
 
 # Auto-fix issues
-python3 -m ruff check --fix portctl.py
+python3 -m ruff check --fix lsport.py
 
 # Format code
-python3 -m ruff format portctl.py
+python3 -m ruff format lsport.py
 ```
 
 **Key style guidelines:**
@@ -126,16 +126,16 @@ python3 -m ruff format portctl.py
 We use mypy for optional type checking:
 
 ```bash
-mypy portctl.py
+mypy lsport.py
 ```
 
 ## Project Structure
 
 ```
-portctl/
-├── portctl.py           # Main CLI application (single file)
+lsport/
+├── lsport.py           # Main CLI application (single file)
 ├── tests/               # Test suite
-│   ├── test_portctl.py  # Unit tests
+│   ├── test_lsport.py  # Unit tests
 │   └── test_cli.py      # CLI integration tests
 ├── pyproject.toml       # Package metadata and entry point
 ├── requirements.txt     # Development dependencies
@@ -183,17 +183,17 @@ test: Add tests for port filtering functionality
 
 ## Development Tips
 
-### Testing portctl locally
+### Testing lsport locally
 
 ```bash
 # Test list command
-./portctl.py list
+./lsport.py list
 
 # Test with state filter
-./portctl.py list -s listen
+./lsport.py list -s listen
 
 # Test kill command (be careful!)
-./portctl.py kill 8080 --yes
+./lsport.py kill 8080 --yes
 ```
 
 ### Debugging
@@ -208,7 +208,7 @@ import pdb; pdb.set_trace()
 
 **"Command not found" after `pipx install`:**
 - Run `pipx ensurepath` and restart your shell
-- Verify the install: `pipx list | grep portctl`
+- Verify the install: `pipx list | grep lsport`
 
 **Tests failing:**
 - Make sure you have all dependencies: `pip install -r requirements.txt`
@@ -224,4 +224,4 @@ Feel free to open an issue with the "question" label, or reach out to the mainta
 
 ## Recognition
 
-Contributors will be recognized in the project README. Thank you for making portctl better!
+Contributors will be recognized in the project README. Thank you for making lsport better!

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# portctl
+# lsport
 
 A fast and elegant command-line utility for inspecting and managing TCP ports on macOS and Linux.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
 
-## What is portctl?
+## What is lsport?
 
-`portctl` helps you quickly identify which processes are occupying TCP ports and terminate them when needed. It provides three modes of operation:
+`lsport` helps you quickly identify which processes are occupying TCP ports and terminate them when needed. It provides three modes of operation:
 
 - **List mode**: View all open TCP ports with process details
 - **Kill mode**: Terminate a process occupying a specific port
@@ -30,10 +30,10 @@ A fast and elegant command-line utility for inspecting and managing TCP ports on
 
 ## Installation
 
-`portctl` is distributed as a standard Python package and installed in an
+`lsport` is distributed as a standard Python package and installed in an
 isolated environment via [`pipx`](https://pipx.pypa.io/). This avoids
 polluting your system Python, never touches `sudo`, and gives you a clean
-`pipx uninstall portctl` when you're done.
+`pipx uninstall lsport` when you're done.
 
 ### 1. Install pipx (one-time)
 
@@ -53,21 +53,21 @@ pipx ensurepath
 
 For other distributions or platforms see the [pipx installation guide](https://pipx.pypa.io/stable/installation/).
 
-### 2. Install portctl
+### 2. Install lsport
 
 ```bash
-git clone https://github.com/0xBroom/portctl.git
-cd portctl
+git clone https://github.com/0xBroom/lsport.git
+cd lsport
 pipx install .
 ```
 
-That's it. `portctl` is now available on your `PATH`, with its dependencies
+That's it. `lsport` is now available on your `PATH`, with its dependencies
 isolated in a dedicated virtual environment under `~/.local/share/pipx/`.
 
 ### Updating
 
 ```bash
-cd portctl
+cd lsport
 git pull
 pipx install . --force
 ```
@@ -75,7 +75,7 @@ pipx install . --force
 ### Uninstalling
 
 ```bash
-pipx uninstall portctl
+pipx uninstall lsport
 ```
 
 ## Usage
@@ -83,7 +83,7 @@ pipx uninstall portctl
 ### List all open ports
 
 ```bash
-portctl list
+lsport list
 ```
 
 Output example:
@@ -100,32 +100,32 @@ Output example:
 
 ```bash
 # Show only listening ports
-portctl list --state listen
+lsport list --state listen
 
 # Show active connections
-portctl list --state established
+lsport list --state established
 
 # Show ports in close_wait state
-portctl list --state close_wait
+lsport list --state close_wait
 ```
 
 ### Kill a process on a specific port
 
 ```bash
 # Interactive kill (asks for confirmation)
-portctl kill 3000
+lsport kill 3000
 
 # Skip confirmation
-portctl kill 3000 --yes
+lsport kill 3000 --yes
 
 # Force kill (SIGKILL instead of SIGTERM)
-portctl kill 3000 --force
+lsport kill 3000 --force
 ```
 
 ### Interactive mode
 
 ```bash
-portctl interactive
+lsport interactive
 ```
 
 Navigate the interactive TUI to:
@@ -135,14 +135,14 @@ Navigate the interactive TUI to:
 
 ## Command Reference
 
-### `portctl list`
+### `lsport list`
 
 Lists all open TCP ports.
 
 **Options:**
 - `-s, --state [listen|established|close_wait]` - Filter by connection state
 
-### `portctl kill <port>`
+### `lsport kill <port>`
 
 Terminates the process occupying the specified port.
 
@@ -150,7 +150,7 @@ Terminates the process occupying the specified port.
 - `-f, --force` - Use SIGKILL instead of SIGTERM
 - `-y, --yes` - Skip confirmation prompt
 
-### `portctl interactive`
+### `lsport interactive`
 
 Launch an interactive TUI to browse and manage ports.
 
@@ -159,8 +159,8 @@ Launch an interactive TUI to browse and manage ports.
 ### Project structure
 
 ```
-portctl/
-├── portctl.py      # Main CLI application
+lsport/
+├── lsport.py      # Main CLI application
 ├── pyproject.toml  # Package metadata and entry point
 ├── LICENSE         # MIT License
 └── README.md       # This file

--- a/docs/audit-2026-04.md
+++ b/docs/audit-2026-04.md
@@ -1,5 +1,7 @@
 # portctl — Auditoría de diseño y seguridad (2026-04)
 
+> **Nota histórica:** este proyecto se renombró a `lsport` en `v0.3.0`. Este documento se conserva tal cual fue escrito en su momento y se refiere al nombre `portctl` por contexto histórico.
+
 > **Snapshot de auditoría — no es una lista de TODOs viva.** Los items que se están trabajando se trackean como issues en GitHub (milestone `v0.2.0` para los P0). Este documento queda como referencia técnica detallada para cada finding.
 
 Análisis del proyecto en estado del commit `57fbbf6`. Cubre `portctl.py`, `install.sh`, tests, CI y packaging.

--- a/lsport.py
+++ b/lsport.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """
-portctl - Fast and elegant TCP port management for macOS and Linux
+lsport - Fast and elegant TCP port management for macOS and Linux
 """
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 import os
 import signal
@@ -22,7 +22,7 @@ VALID_STATES = ("LISTEN", "ESTABLISHED", "CLOSE_WAIT")
 
 app = typer.Typer(
     help=(
-        "🔌 portctl — Inspect and manage open TCP ports.\n\n"
+        "🔌 lsport — Inspect and manage open TCP ports.\n\n"
         "Available commands:\n\n"
         "  list          List all open ports (TCP).\n"
         "                Use -s/--state to filter by state.\n\n"
@@ -144,10 +144,10 @@ def kill_port(port: int, force: bool = False) -> bool:
         "Without options, shows all (LISTEN, ESTABLISHED, CLOSE_WAIT).\n"
         "Use -s/--state to filter by a specific state.\n\n"
         "Examples:\n\n"
-        "  portctl list\n"
-        "  portctl list -s listen\n"
-        "  portctl list -s established\n"
-        "  portctl list -s close_wait"
+        "  lsport list\n"
+        "  lsport list -s listen\n"
+        "  lsport list -s established\n"
+        "  lsport list -s close_wait"
     ),
 )
 def cmd_list(
@@ -173,7 +173,7 @@ def cmd_list(
         console.print(Panel(f"[yellow]No open ports found[/]{hint}", border_style="yellow"))
         return
 
-    label = f"[bold white]🔌 portctl[/] [bright_black]—[/] [cyan]{len(ports)} ports found[/]"
+    label = f"[bold white]🔌 lsport[/] [bright_black]—[/] [cyan]{len(ports)} ports found[/]"
     if state:
         label += f"  [bright_black]({state.upper()})[/]"
 
@@ -191,9 +191,9 @@ def cmd_list(
         "Use --force to send SIGKILL instead of SIGTERM.\n"
         "Use --yes to skip confirmation (useful in scripts).\n\n"
         "Examples:\n\n"
-        "  portctl kill 3000\n"
-        "  portctl kill 8080 --force\n"
-        "  portctl kill 5433 --yes"
+        "  lsport kill 3000\n"
+        "  lsport kill 8080 --force\n"
+        "  lsport kill 5433 --yes"
     ),
 )
 def cmd_kill(
@@ -249,7 +249,7 @@ def cmd_interactive():
         console.print()
         console.print(
             Panel(
-                "[bold white]🔌 portctl[/] [bright_black]—[/] [cyan]interactive mode[/]",
+                "[bold white]🔌 lsport[/] [bright_black]—[/] [cyan]interactive mode[/]",
                 border_style="bright_black",
                 expand=False,
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "portctl"
-version = "0.2.0"
+name = "lsport"
+version = "0.3.0"
 description = "A fast and elegant command-line utility for inspecting and managing TCP ports on macOS and Linux"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -38,15 +38,15 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/0xBroom/portctl"
-Repository = "https://github.com/0xBroom/portctl"
-Issues = "https://github.com/0xBroom/portctl/issues"
+Homepage = "https://github.com/0xBroom/lsport"
+Repository = "https://github.com/0xBroom/lsport"
+Issues = "https://github.com/0xBroom/lsport/issues"
 
 [project.scripts]
-portctl = "portctl:app"
+lsport = "lsport:app"
 
 [tool.setuptools]
-py-modules = ["portctl"]
+py-modules = ["lsport"]
 
 [tool.ruff]
 line-length = 120

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,10 +1,10 @@
-# Tests for portctl
+# Tests for lsport
 
-This directory contains the test suite for portctl.
+This directory contains the test suite for lsport.
 
 ## Test Structure
 
-- `test_portctl.py` - Unit tests for core functions
+- `test_lsport.py` - Unit tests for core functions
 - `test_cli.py` - Integration tests for CLI commands
 
 ## Running Tests
@@ -14,13 +14,13 @@ This directory contains the test suite for portctl.
 pytest
 
 # Run with coverage
-pytest --cov=portctl
+pytest --cov=lsport
 
 # Run specific test file
-pytest tests/test_portctl.py
+pytest tests/test_lsport.py
 
 # Run specific test
-pytest tests/test_portctl.py::TestGetOpenPorts::test_get_open_ports_basic
+pytest tests/test_lsport.py::TestGetOpenPorts::test_get_open_ports_basic
 ```
 
 ## Test Coverage

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,5 @@
 """
-Integration tests for portctl CLI commands
+Integration tests for lsport CLI commands
 """
 
 import os
@@ -11,7 +11,7 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from portctl import app
+from lsport import app
 
 runner = CliRunner()
 
@@ -19,7 +19,7 @@ runner = CliRunner()
 class TestListCommand:
     """Test the list command"""
 
-    @patch("portctl.get_open_ports")
+    @patch("lsport.get_open_ports")
     def test_list_no_ports(self, mock_get_ports):
         """Test list command when no ports are open"""
         mock_get_ports.return_value = []
@@ -29,7 +29,7 @@ class TestListCommand:
         assert result.exit_code == 0
         assert "No open ports found" in result.stdout
 
-    @patch("portctl.get_open_ports")
+    @patch("lsport.get_open_ports")
     def test_list_with_ports(self, mock_get_ports):
         """Test list command with open ports"""
         mock_get_ports.return_value = [
@@ -51,7 +51,7 @@ class TestListCommand:
         assert "test-app" in result.stdout
         assert "LISTEN" in result.stdout
 
-    @patch("portctl.get_open_ports")
+    @patch("lsport.get_open_ports")
     def test_list_with_state_filter(self, mock_get_ports):
         """Test list command with state filter"""
         mock_get_ports.return_value = []
@@ -72,8 +72,8 @@ class TestListCommand:
 class TestKillCommand:
     """Test the kill command"""
 
-    @patch("portctl.kill_port")
-    @patch("portctl.get_open_ports")
+    @patch("lsport.kill_port")
+    @patch("lsport.get_open_ports")
     def test_kill_no_process_on_port(self, mock_get_ports, mock_kill_port):
         """Test kill command when no process is on the port"""
         mock_get_ports.return_value = []
@@ -83,8 +83,8 @@ class TestKillCommand:
         assert result.exit_code == 1
         assert "No process found" in result.stdout
 
-    @patch("portctl.kill_port")
-    @patch("portctl.get_open_ports")
+    @patch("lsport.kill_port")
+    @patch("lsport.get_open_ports")
     def test_kill_with_yes_flag(self, mock_get_ports, mock_kill_port):
         """Test kill command with --yes flag"""
         mock_get_ports.return_value = [
@@ -106,8 +106,8 @@ class TestKillCommand:
         mock_kill_port.assert_called_once_with(8080, force=False)
         assert "Closed" in result.stdout
 
-    @patch("portctl.kill_port")
-    @patch("portctl.get_open_ports")
+    @patch("lsport.kill_port")
+    @patch("lsport.get_open_ports")
     def test_kill_with_force_flag(self, mock_get_ports, mock_kill_port):
         """Test kill command with --force flag"""
         mock_get_ports.return_value = [
@@ -128,8 +128,8 @@ class TestKillCommand:
         assert result.exit_code == 0
         mock_kill_port.assert_called_once_with(8080, force=True)
 
-    @patch("portctl.kill_port")
-    @patch("portctl.get_open_ports")
+    @patch("lsport.kill_port")
+    @patch("lsport.get_open_ports")
     def test_kill_cancelled(self, mock_get_ports, mock_kill_port):
         """Test kill command when user cancels"""
         mock_get_ports.return_value = [
@@ -160,7 +160,7 @@ class TestAppHelp:
         result = runner.invoke(app, ["--help"])
 
         assert result.exit_code == 0
-        assert "portctl" in result.stdout
+        assert "lsport" in result.stdout
         assert "list" in result.stdout
         assert "kill" in result.stdout
         assert "interactive" in result.stdout

--- a/tests/test_lsport.py
+++ b/tests/test_lsport.py
@@ -1,23 +1,23 @@
 """
-Unit tests for portctl core functionality
+Unit tests for lsport core functionality
 """
 
 import os
 
-# Import functions from portctl
+# Import functions from lsport
 import sys
 from unittest.mock import Mock, patch
 
 import psutil
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from portctl import VALID_STATES, get_open_ports, kill_port, status_color
+from lsport import VALID_STATES, get_open_ports, kill_port, status_color
 
 
 class TestGetOpenPorts:
     """Test the get_open_ports function"""
 
-    @patch("portctl.psutil.process_iter")
+    @patch("lsport.psutil.process_iter")
     def test_get_open_ports_basic(self, mock_process_iter):
         """Test basic port listing"""
         # Create mock process
@@ -45,7 +45,7 @@ class TestGetOpenPorts:
         assert ports[0]["status"] == "LISTEN"
         assert ports[0]["proto"] == "TCP"
 
-    @patch("portctl.psutil.process_iter")
+    @patch("lsport.psutil.process_iter")
     def test_get_open_ports_filter_by_port(self, mock_process_iter):
         """Test filtering by specific port"""
         mock_proc = Mock()
@@ -69,7 +69,7 @@ class TestGetOpenPorts:
         assert len(ports) == 1
         assert ports[0]["port"] == 8080
 
-    @patch("portctl.psutil.process_iter")
+    @patch("lsport.psutil.process_iter")
     def test_get_open_ports_filter_by_state(self, mock_process_iter):
         """Test filtering by connection state"""
         mock_proc = Mock()
@@ -93,7 +93,7 @@ class TestGetOpenPorts:
         assert len(ports) == 1
         assert ports[0]["status"] == "LISTEN"
 
-    @patch("portctl.psutil.process_iter")
+    @patch("lsport.psutil.process_iter")
     def test_get_open_ports_handles_no_such_process(self, mock_process_iter):
         """Test that NoSuchProcess exceptions are handled gracefully"""
         mock_proc = Mock()
@@ -104,7 +104,7 @@ class TestGetOpenPorts:
         ports = get_open_ports()
         assert len(ports) == 0
 
-    @patch("portctl.psutil.process_iter")
+    @patch("lsport.psutil.process_iter")
     def test_get_open_ports_handles_access_denied(self, mock_process_iter):
         """Test that AccessDenied exceptions are handled gracefully"""
         mock_proc = Mock()
@@ -115,7 +115,7 @@ class TestGetOpenPorts:
         ports = get_open_ports()
         assert len(ports) == 0
 
-    @patch("portctl.psutil.process_iter")
+    @patch("lsport.psutil.process_iter")
     def test_get_open_ports_handles_runtime_error(self, mock_process_iter):
         """Regression: psutil's macOS C extension can leak RuntimeError from
         proc_pidinfo(PROC_PIDLISTFDS); the iteration must not die. (Issue #9)"""
@@ -126,7 +126,7 @@ class TestGetOpenPorts:
         ports = get_open_ports()
         assert len(ports) == 0
 
-    @patch("portctl.psutil.process_iter")
+    @patch("lsport.psutil.process_iter")
     def test_get_open_ports_continues_after_runtime_error(self, mock_process_iter):
         """Regression: a bad PID raising RuntimeError must not prevent the
         rest of the iteration from being scanned. (Issue #9)"""
@@ -148,7 +148,7 @@ class TestGetOpenPorts:
         assert ports[0]["port"] == 8080
         assert ports[0]["pid"] == 4321
 
-    @patch("portctl.psutil.process_iter")
+    @patch("lsport.psutil.process_iter")
     def test_get_open_ports_sorts_by_port(self, mock_process_iter):
         """Test that results are sorted by port number"""
         mock_proc = Mock()
@@ -193,8 +193,8 @@ class TestStatusColor:
 class TestKillPort:
     """Test the kill_port function"""
 
-    @patch("portctl.os.kill")
-    @patch("portctl.psutil.process_iter")
+    @patch("lsport.os.kill")
+    @patch("lsport.psutil.process_iter")
     def test_kill_port_success(self, mock_process_iter, mock_os_kill):
         """Test successfully killing a process on a port"""
         mock_proc = Mock()
@@ -211,7 +211,7 @@ class TestKillPort:
         assert result is True
         mock_os_kill.assert_called_once()
 
-    @patch("portctl.psutil.process_iter")
+    @patch("lsport.psutil.process_iter")
     def test_kill_port_not_found(self, mock_process_iter):
         """Test killing a port that doesn't exist"""
         mock_process_iter.return_value = []
@@ -220,8 +220,8 @@ class TestKillPort:
 
         assert result is False
 
-    @patch("portctl.os.kill")
-    @patch("portctl.psutil.process_iter")
+    @patch("lsport.os.kill")
+    @patch("lsport.psutil.process_iter")
     def test_kill_port_with_force(self, mock_process_iter, mock_os_kill):
         """Test force killing with SIGKILL"""
         import signal
@@ -240,8 +240,8 @@ class TestKillPort:
         assert result is True
         mock_os_kill.assert_called_with(1234, signal.SIGKILL)
 
-    @patch("portctl.os.kill")
-    @patch("portctl.psutil.process_iter")
+    @patch("lsport.os.kill")
+    @patch("lsport.psutil.process_iter")
     def test_kill_port_skips_runtime_error_and_kills_target(self, mock_process_iter, mock_os_kill):
         """Regression: a bad PID raising RuntimeError must not prevent the
         target on a later PID from being killed. (Issue #9)"""


### PR DESCRIPTION
## Summary

Renames the project from `portctl` to `lsport` and bumps to **v0.3.0**. This is a **breaking change** — the `portctl` command no longer exists.

GitHub repo was already renamed (`0xBroom/portctl` → `0xBroom/lsport`); PyPI name `lsport` reserved via Trusted Publishing pending publisher. This PR enables OIDC publishing on tag push, so `v0.3.0` will become the first release published to PyPI.

## Migration for users

```bash
pipx uninstall portctl
pipx install lsport
```

For Python imports: `from portctl import ...` → `from lsport import ...`.

For local clones: `git remote set-url origin git@github.com:0xBroom/lsport.git` (GitHub redirects also work).

## Changes

- `portctl.py` → `lsport.py` (renamed via `git mv`, history preserved)
- `tests/test_portctl.py` → `tests/test_lsport.py`
- `pyproject.toml`: package name `lsport`, version `0.3.0`, scripts, py-modules and URLs updated
- All internal branding, help text, README, CONTRIBUTING, issue/PR templates, tests/README and CI ruff target paths updated
- `CHANGELOG.md`: new `[0.3.0]` entry with migration instructions; historical `[0.2.0]` / `[0.1.0]` entries preserved verbatim
- `docs/audit-2026-04.md`: added a note at the top marking it as a historical snapshot from when the project was named `portctl`
- `.github/workflows/release.yml`: enabled the `pypi-publish` job using Trusted Publishing (OIDC, `id-token: write`, environment `pypi`, URL `https://pypi.org/p/lsport`)
- Removed stale build artifacts (`portctl.egg-info/`, `build/`, `__pycache__/`)

## Test plan

- [x] `pytest tests/ -v` — 28/28 pass
- [x] `ruff check lsport.py tests` — clean
- [x] `ruff format --check lsport.py tests` — clean
- [x] `pipx install --editable .` succeeds and exposes `lsport` on PATH
- [x] `lsport --help` renders correctly with new branding
- [x] `lsport list` and `lsport list -s listen` work end-to-end on macOS

## Release

Once merged, tagging `v0.3.0` triggers `release.yml`, which:
1. Builds the sdist + wheel
2. Creates the GitHub Release
3. Publishes to PyPI as `lsport` via Trusted Publishing