### PR TITLE
chore: release v0.3.1 (docs-only — refresh PyPI README)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-05-09
+
+### Changed
+
+- **Docs-only release.** Exists solely to refresh the README rendered on
+  PyPI now that `lsport` is published there.
+  - Install instructions now use `pipx install lsport` directly instead of
+    cloning the repository.
+  - `pipx upgrade lsport` replaces the previous `git pull && pipx install . --force`
+    upgrade flow.
+  - Added an "Install from source" section pointing to `CONTRIBUTING.md`
+    for the editable / contributor flow.
+  - Refreshed the badge row with PyPI version, Python versions (auto-derived
+    from `requires-python`), and monthly downloads.
+- No runtime, packaging, or behavioral changes — `lsport.py` is identical
+  to `0.3.0` except for the `__version__` bump.
+
 ## [0.3.0] - 2026-05-09
 
 ### BREAKING
@@ -98,6 +115,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved type annotations and formatting consistency.
 - Added linting and formatting configuration via Ruff.
 
+[0.3.1]: https://github.com/0xBroom/lsport/releases/tag/v0.3.1
 [0.3.0]: https://github.com/0xBroom/lsport/releases/tag/v0.3.0
 [0.2.0]: https://github.com/0xBroom/lsport/releases/tag/v0.2.0
 [0.1.0]: https://github.com/0xBroom/lsport/releases/tag/v0.1.0

--- a/lsport.py
+++ b/lsport.py
@@ -3,7 +3,7 @@
 lsport - Fast and elegant TCP port management for macOS and Linux
 """
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 import os
 import signal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lsport"
-version = "0.3.0"
+version = "0.3.1"
 description = "A fast and elegant command-line utility for inspecting and managing TCP ports on macOS and Linux"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Cuts a docs-only patch release `v0.3.1` so that the README on PyPI is
republished with the `pipx install lsport` instructions merged in #14.

PyPI versions are **immutable** — once `v0.3.0` was uploaded, its rendered
README is frozen forever. The only way to update the canonical PyPI page
is to publish a new version. This is that new version: no runtime change,
no API change, just a new build of the wheel and sdist with the updated
`README.md` baked in.

## Changes

- `pyproject.toml`: `version` `0.3.0` → `0.3.1`
- `lsport.py`: `__version__` `0.3.0` → `0.3.1`
- `CHANGELOG.md`: new `[0.3.1]` entry documenting the docs-only nature

`lsport.py` is otherwise byte-identical to `0.3.0`.

## Why a release for a doc?

`v0.3.0` is the first PyPI release. The PyPI page is the first impression
for anyone landing from search, social, or third-party links. Showing
clone instructions when the canonical install is `pipx install lsport`
is bad optics during the launch window. Patch numbers are cheap pre-1.0;
the PyPI page being correct is not.

## Release plan

After merge:
1. Tag `v0.3.1` on the merge commit
2. Push the tag → triggers `release.yml` (build → GitHub release → PyPI publish via OIDC)
3. PyPI page renders the new README within ~5 minutes of upload

## Test plan

- [x] `pyproject.toml` and `lsport.py` versions match
- [x] CHANGELOG `[0.3.1]` entry added with link reference at the bottom
- [ ] After release, verify <https://pypi.org/project/lsport/> renders the
      updated README (badges + `pipx install lsport` as the primary command)